### PR TITLE
Add Matplotlib framework classifier to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
+    "Framework :: Matplotlib",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Sorry it got stalled so badly on the main repo. Also please add this to https://matplotlib.org/thirdpartypackages/